### PR TITLE
SUMO-219853: gradle changes to push jar to jfrog

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -178,7 +178,6 @@ publishing {
             }
         }
     }
-}
 
     repositories {
         maven {
@@ -205,8 +204,4 @@ artifactory {
             setPublishPom(true)
         }
     }
-}
-
-tasks.register("publishToArtifactory") {
-    dependsOn("publish")
 }


### PR DESCRIPTION
Since the main branch of the original repo is ahead of their latest stable release version i.e. `2.2.21`, thus created a new branch by the name `2.2.21-modified` from the tag `2.2.21`.

Will merge all future changes in this branch itself i.e. `2.2.21-modified`.

The changes in this PR will build and push the jar to our jFrog artifactory.

Tested it locally.

<img width="1728" alt="Screenshot 2023-05-03 at 6 03 16 PM" src="https://user-images.githubusercontent.com/93508079/235917104-cf7022e3-ff44-4719-822f-f0dde341c0dd.png">


