### PR TITLE
introduce new constructor for sftp v3 client

### DIFF
--- a/src/main/java/com/trilead/ssh2/SFTPv3Client.java
+++ b/src/main/java/com/trilead/ssh2/SFTPv3Client.java
@@ -115,11 +115,11 @@ public class SFTPv3Client
 	 *
 	 * @param conn The underlying SSH-2 connection to be used.
 	 * @param debug
-	 * @param command command want to execute after creating session, if non-null value given, sftp subsystem won't get triggered
+	 * @param sftpServerExecuteCommand custom command to execute sftp server on remote machine
 	 * @throws IOException
 	 *
 	 */
-	public SFTPv3Client(Connection conn, PrintStream debug, String command) throws IOException
+	public SFTPv3Client(Connection conn, PrintStream debug, String sftpServerExecuteCommand) throws IOException
 	{
 		if (conn == null)
 			throw new IllegalArgumentException("Cannot accept null argument!");
@@ -131,10 +131,10 @@ public class SFTPv3Client
 			debug.println("Opening session and starting SFTP subsystem.");
 
 		sess = conn.openSession();
-		if (command == null || command.trim().length() == 0) {
+		if (sftpServerExecuteCommand == null || sftpServerExecuteCommand.trim().length() == 0) {
 			sess.startSubSystem("sftp");
 		} else {
-			sess.execCommand(command.trim());
+			sess.execCommand(sftpServerExecuteCommand.trim());
 		}
 
 		is = sess.getStdout();
@@ -145,7 +145,7 @@ public class SFTPv3Client
 
 		init();
 	}
-	
+
 	/**
 	 * Create a SFTP v3 client.
 	 *

--- a/src/main/java/com/trilead/ssh2/SFTPv3Client.java
+++ b/src/main/java/com/trilead/ssh2/SFTPv3Client.java
@@ -114,6 +114,42 @@ public class SFTPv3Client
 	 * Create a SFTP v3 client.
 	 *
 	 * @param conn The underlying SSH-2 connection to be used.
+	 * @param debug
+	 * @param command command want to execute after creating session, if non-null value given, sftp subsystem won't get triggered
+	 * @throws IOException
+	 *
+	 */
+	public SFTPv3Client(Connection conn, PrintStream debug, String command) throws IOException
+	{
+		if (conn == null)
+			throw new IllegalArgumentException("Cannot accept null argument!");
+
+		this.conn = conn;
+		this.debug = debug;
+
+		if (debug != null)
+			debug.println("Opening session and starting SFTP subsystem.");
+
+		sess = conn.openSession();
+		if (command == null || command.trim().length() == 0) {
+			sess.startSubSystem("sftp");
+		} else {
+			sess.execCommand(command.trim());
+		}
+
+		is = sess.getStdout();
+		os = new BufferedOutputStream(sess.getStdin(), 2048);
+
+		if ((is == null) || (os == null))
+			throw new IOException("There is a problem with the streams of the underlying channel.");
+
+		init();
+	}
+	
+	/**
+	 * Create a SFTP v3 client.
+	 *
+	 * @param conn The underlying SSH-2 connection to be used.
 	 * @throws IOException
 	 */
 	public SFTPv3Client(Connection conn) throws IOException


### PR DESCRIPTION
The requirement is to run a specific command for starting the sftp server on the remote machine instead of the default `sftp` subsystem. Thus created a new constructor for SftpV3Client which takes an extra parameter i.e. sftpServerExecuteCommand. If the extra parameter is not null and empty, we will execute this command, else it will work as usual.

the code change is 
```
if (sftpServerExecuteCommand == null || sftpServerExecuteCommand.trim().length() == 0) {
	sess.startSubSystem("sftp");
} else {
	sess.execCommand(sftpServerExecuteCommand.trim());
}
```
rest has been referred from` com.trilead.ssh2.SFTPv3Client#SFTPv3Client(com.trilead.ssh2.Connection, java.io.PrintStream)`


`./gradlew build` is green.

<img width="1728" alt="Screenshot 2023-05-08 at 2 58 55 PM" src="https://user-images.githubusercontent.com/93508079/236789130-36064a66-d736-478f-af9e-26782d76880e.png">
