### PR TITLE
SUMO-220008: change version name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-version=2.2.21
+version=2.2.21-modified
 group=org.connectbot
 description=SSH library used in the ConnectBot app
 


### PR DESCRIPTION
change the version name in order to remove the confusion between Sanyaku's 2.2.21 versions and connectbot's 2.2.21 version