### PR TITLE
Update tink dependency version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,7 +46,7 @@ apply(from = "$rootDir/config/quality.gradle.kts")
 dependencies {
     implementation("com.jcraft:jzlib:1.1.3")
     implementation("org.connectbot:simplesocks:1.0.1")
-    implementation("com.google.crypto.tink:tink:1.7.0")
+    implementation("com.google.crypto.tink:tink:1.11.0")
     implementation("org.connectbot:jbcrypt:1.0.2")
 
     testImplementation("junit:junit:4.13.2")

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,7 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-version=2.2.21-sumo-exec-command-support
+version=2.2.21-sumo-exec-command-support-new
 group=org.connectbot
 description=SSH library used in the ConnectBot app
 


### PR DESCRIPTION
Need to update tink dependency version since it uses newer version of protobuf-java required to resolve CVE's.